### PR TITLE
contentスクリプト内で使うオプションの取得方法を変更した

### DIFF
--- a/extension/js/content.js
+++ b/extension/js/content.js
@@ -1,32 +1,47 @@
 (function() {
-  $(document).ready(function() {
-    var elm_autocomplete, elm_replace, i, len, loaded_emoji, new_img, options, reload;
-    elm_replace = $("body");
-    elm_autocomplete = $("[contentEditable=true], textarea");
-    if (elm_replace.find('.emojidex-emoji').length === 0) {
-      if (autoReplace) {
-        options = {
-          autoUpdate: autoUpdate
-        };
-        elm_replace.emojidexReplace(options);
-      }
-    } else {
-      loaded_emoji = elm_replace.find('.emojidex-emoji');
-      for (i = 0, len = loaded_emoji.length; i < len; i++) {
-        reload = loaded_emoji[i];
-        new_img = "<img class='" + reload.className + "' src='" + reload.src + "' title='" + reload.title + "' ></img>";
-        $(reload).replaceWith(new_img);
-      }
-    }
-    if (setAutocomplete) {
-      if (tab_url.match(/twitter.com/)) {
-        return elm_autocomplete.emojidexAutocomplete({
-          insertImg: false
-        });
+  var optionsPort;
+
+  optionsPort = chrome.runtime.connect();
+
+  optionsPort.postMessage({
+    method: 'getOptions'
+  });
+
+  optionsPort.onMessage.addListener(function(options) {
+    return $(document).ready(function() {
+      var elm_autocomplete, elm_replace, excuteReplaeWithFlag, i, len, loaded_emoji, new_img, reload;
+      excuteReplaeWithFlag = function() {
+        var replace_options;
+        if (options.autoReplace) {
+          replace_options = {
+            autoUpdate: options.autoUpdate
+          };
+          return elm_replace.emojidexReplace(replace_options);
+        }
+      };
+      elm_replace = $("body");
+      elm_autocomplete = $("[contentEditable=true], textarea");
+      if (elm_replace.find('.emojidex-emoji').length === 0) {
+        excuteReplaeWithFlag();
       } else {
-        return elm_autocomplete.emojidexAutocomplete();
+        loaded_emoji = elm_replace.find('.emojidex-emoji');
+        for (i = 0, len = loaded_emoji.length; i < len; i++) {
+          reload = loaded_emoji[i];
+          new_img = "<img class='" + reload.className + "' src='" + reload.src + "' title='" + reload.title + "' ></img>";
+          $(reload).replaceWith(new_img);
+        }
+        excuteReplaeWithFlag();
       }
-    }
+      if (options.setAutocomplete) {
+        if (options.currentTabUrl.match(/twitter.com/)) {
+          return elm_autocomplete.emojidexAutocomplete({
+            insertImg: false
+          });
+        } else {
+          return elm_autocomplete.emojidexAutocomplete();
+        }
+      }
+    });
   });
 
 }).call(this);

--- a/package.json
+++ b/package.json
@@ -2,6 +2,12 @@
   "name": "emojidex-chrome_extension",
   "version": "0.3.4",
   "description": "emojidex for chrome extension",
+  "license": {
+    "description": "Licensed under the emojidex Open License",
+    "type": "emojiOL",
+    "url": "https://www.emojidex.com/emojidex/emojidex_open_license",
+    "copyright": "Copyright 2013 the emojidex project / K.K. GenSouSha"
+  },
   "devDependencies": {
     "emojidex": ">=0.15.2",
     "grunt": "~1.0.1",
@@ -11,17 +17,15 @@
     "grunt-contrib-copy": "^1.0.0",
     "grunt-contrib-watch": "~1.0.0",
     "grunt-cson": "^0.17.0",
-    "grunt-slim": "^0.1.0"
-  },
-  "scripts": {
-    "test": "grunt travis --verbose"
+    "grunt-slim": "^0.1.0",
+    "bower": "^1.8.2"
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/Genshin/emojidex-chrome_extension.git"
+    "url": "git@github.com:emojidex/emojidex-chrome_extension.git"
   },
-  "author": "Genshin",
+  "author": "emojidex",
   "bugs": {
-    "url": "https://github.com/Genshin/emojidex-chrome_extension/issues"
+    "url": "https://github.com/emojidex/emojidex-chrome_extension"
   }
 }

--- a/src/coffee/content.coffee
+++ b/src/coffee/content.coffee
@@ -1,25 +1,32 @@
-$(document).ready ->
-  elm_replace = $("body")
-  elm_autocomplete = $("[contentEditable=true], textarea")
+optionsPort = chrome.runtime.connect()
+optionsPort.postMessage method: 'getOptions'
+optionsPort.onMessage.addListener (options) ->
+  $(document).ready ->
+    excuteReplaeWithFlag = () ->
+      if options.autoReplace
+        replace_options =
+          autoUpdate: options.autoUpdate
+        elm_replace.emojidexReplace replace_options
 
-  if elm_replace.find('.emojidex-emoji').length is 0
-    if autoReplace
-      options =
-        autoUpdate: autoUpdate
-      elm_replace.emojidexReplace options
-  else
-    loaded_emoji = elm_replace.find('.emojidex-emoji')
-    for reload in loaded_emoji
-      new_img = "<img
-        class='#{reload.className}'
-        src='#{reload.src}'
-        title='#{reload.title}'
-      ></img>"
-      $(reload).replaceWith new_img
+    elm_replace = $("body")
+    elm_autocomplete = $("[contentEditable=true], textarea")
 
-  if setAutocomplete
-    if tab_url.match /twitter.com/
-      elm_autocomplete.emojidexAutocomplete
-        insertImg: false
+    if elm_replace.find('.emojidex-emoji').length is 0
+      excuteReplaeWithFlag()
     else
-      elm_autocomplete.emojidexAutocomplete()
+      loaded_emoji = elm_replace.find('.emojidex-emoji')
+      for reload in loaded_emoji
+        new_img = "<img
+          class='#{reload.className}'
+          src='#{reload.src}'
+          title='#{reload.title}'
+        ></img>"
+        $(reload).replaceWith new_img
+      excuteReplaeWithFlag()
+
+    if options.setAutocomplete
+      if options.currentTabUrl.match /twitter.com/
+        elm_autocomplete.emojidexAutocomplete
+          insertImg: false
+      else
+        elm_autocomplete.emojidexAutocomplete()

--- a/yarn.lock
+++ b/yarn.lock
@@ -66,6 +66,10 @@ body-parser@~1.14.0:
     raw-body "~2.1.5"
     type-is "~1.6.10"
 
+bower@^1.8.2:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/bower/-/bower-1.8.2.tgz#adf53529c8d4af02ef24fb8d5341c1419d33e2f7"
+
 brace-expansion@^1.0.0:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.7.tgz#3effc3c50e000531fb720eaff80f0ae8ef23cf59"


### PR DESCRIPTION
content内で使うオプション値の取得方法を、background内でexecuteScriptして変数を渡す方法から、chrome.runtimeを使う方法に変更した。
- chrome.runtime.connectとchrome.runtime.onConnectを使う方法に変更
- contentスクリプトを一部修正
- 不要なコメントを整理